### PR TITLE
Add Windows release workflow and documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout (with submodules)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -57,7 +57,7 @@ jobs:
           Compress-Archive -Path $stage -DestinationPath $zip -Force
 
       - name: Upload workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: assurance-forge-${{ steps.version.outputs.version }}-windows-x64
           path: package/assurance-forge.${{ steps.version.outputs.version }}.zip
@@ -65,7 +65,7 @@ jobs:
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: assurance-forge ${{ steps.version.outputs.version }}
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,14 +53,14 @@ jobs:
         run: |
           $version = "${{ steps.version.outputs.version }}"
           $stage = "package/assurance-forge.$version"
-          $zip = "package/assurance-forge.$version.zip"
+          $zip = "package/assurance-forge.$version-windows-x64.zip"
           Compress-Archive -Path $stage -DestinationPath $zip -Force
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v6
         with:
           name: assurance-forge-${{ steps.version.outputs.version }}-windows-x64
-          path: package/assurance-forge.${{ steps.version.outputs.version }}.zip
+          path: package/assurance-forge.${{ steps.version.outputs.version }}-windows-x64.zip
           if-no-files-found: error
 
       - name: Create GitHub Release
@@ -69,5 +69,5 @@ jobs:
         with:
           name: assurance-forge ${{ steps.version.outputs.version }}
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
-          files: package/assurance-forge.${{ steps.version.outputs.version }}.zip
+          files: package/assurance-forge.${{ steps.version.outputs.version }}-windows-x64.zip
           fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Build (Release)
         run: cmake --build build --config Release
 
-      - name: Run tests
-        run: ctest --test-dir build -C Release --output-on-failure
-
       - name: Determine package version
         id: version
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows:
+    name: Build (Windows)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Configure CMake
+        run: cmake -B build -G "Visual Studio 17 2022" -A x64
+
+      - name: Build (Release)
+        run: cmake --build build --config Release
+
+      - name: Run tests
+        run: ctest --test-dir build -C Release --output-on-failure
+
+      - name: Determine package version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=dev-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Stage package contents
+        shell: bash
+        run: |
+          set -euo pipefail
+          stage="package/assurance-forge.${{ steps.version.outputs.version }}"
+          mkdir -p "$stage"
+          cp build/Release/assurance-forge.exe "$stage/"
+          cp -r data "$stage/"
+          cp README.md "$stage/"
+          cp LICENSE.md "$stage/"
+
+      - name: Create zip
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          $stage = "package/assurance-forge.$version"
+          $zip = "package/assurance-forge.$version.zip"
+          Compress-Archive -Path $stage -DestinationPath $zip -Force
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: assurance-forge-${{ steps.version.outputs.version }}-windows-x64
+          path: package/assurance-forge.${{ steps.version.outputs.version }}.zip
+          if-no-files-found: error
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          name: assurance-forge ${{ steps.version.outputs.version }}
+          prerelease: ${{ contains(steps.version.outputs.version, '-') }}
+          files: package/assurance-forge.${{ steps.version.outputs.version }}.zip
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ Users work with assurance content, not diagram layout.
 See docs/ROADMAP.md
 
 ---
+
+## 📦 Releases
+
+Pre-built Windows binaries are published on the [Releases page](https://github.com/lasrod/assurance-forge/releases).
+
+1. Download `assurance-forge.<version>.zip` from the latest release.
+2. Unzip anywhere.
+3. Run `assurance-forge.exe` from the extracted folder.
+
+Each zip contains the executable, the `data/` sample files, `README.md`, and `LICENSE.md`.
+
+Releases are currently Windows x64 only. To build on other platforms, see [Build Instructions](#build-instructions) below.
+
+---
 ## Requirements
 
 - Windows 10/11

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ See docs/ROADMAP.md
 
 Pre-built Windows binaries are published on the [Releases page](https://github.com/lasrod/assurance-forge/releases).
 
-1. Download `assurance-forge.<version>.zip` from the latest release.
+1. Download `assurance-forge.<version>-windows-x64.zip` from the latest release.
 2. Unzip anywhere.
 3. Run `assurance-forge.exe` from the extracted folder.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -24,7 +24,7 @@ Tags containing `-` are automatically marked as **prerelease** by the workflow.
 3. The `Release` workflow builds the project, packages a zip, and creates a GitHub Release named `assurance-forge <tag>` with the zip attached.
 4. Edit the Release on GitHub to add a description. The workflow leaves the body empty intentionally so the release notes can be written by hand.
 
-The release zip is named `assurance-forge.<tag>.zip` and contains:
+The release zip is named `assurance-forge.<tag>-windows-x64.zip` and contains:
 
 - `assurance-forge.exe`
 - `data/` (sample SACM files)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,48 @@
+# Releasing
+
+This project uses an automated GitHub Actions workflow (`.github/workflows/release.yml`) to build Windows binaries and publish releases.
+
+## Tag conventions
+
+Tags use semantic versioning **without a `v` prefix**:
+
+- Stable: `<major>.<minor>.<patch>` — e.g. `0.2.0`, `1.0.0`
+- Prerelease: `<major>.<minor>.<patch>-<label>` — e.g. `0.1.0-alpha.5`, `1.0.0-rc.1`
+
+Tags containing `-` are automatically marked as **prerelease** by the workflow.
+
+## Cutting a release
+
+1. Make sure `main` is in the state you want to release.
+2. Tag the commit and push the tag:
+
+   ```bash
+   git tag 0.2.0
+   git push origin 0.2.0
+   ```
+
+3. The `Release` workflow builds the project, runs tests, packages a zip, and creates a GitHub Release named `assurance-forge <tag>` with the zip attached.
+4. Edit the Release on GitHub to add a description. The workflow leaves the body empty intentionally so the release notes can be written by hand.
+
+The release zip is named `assurance-forge.<tag>.zip` and contains:
+
+- `assurance-forge.exe`
+- `data/` (sample SACM files)
+- `README.md`
+- `LICENSE.md`
+
+## Experimental builds (no release)
+
+To build a packaged zip without creating a GitHub Release, use **workflow_dispatch**:
+
+1. Go to **Actions → Release → Run workflow** on GitHub.
+2. Pick a branch and click *Run workflow*.
+3. When the run finishes, download the zip from the run's *Artifacts* section.
+
+`workflow_dispatch` builds use a `dev-<short-sha>` version string and never create a GitHub Release — even when run from the default branch.
+
+> Note: `workflow_dispatch` only works for workflow files that exist on the repository's default branch. To run an experimental build from a feature branch, the workflow file must already be present on `main`.
+
+## Platform support
+
+Releases are currently **Windows x64 only**, built with the `Visual Studio 17 2022` generator on GitHub-hosted `windows-latest` runners. Cross-platform release artifacts are tracked separately on the roadmap.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -21,7 +21,7 @@ Tags containing `-` are automatically marked as **prerelease** by the workflow.
    git push origin 0.2.0
    ```
 
-3. The `Release` workflow builds the project, runs tests, packages a zip, and creates a GitHub Release named `assurance-forge <tag>` with the zip attached.
+3. The `Release` workflow builds the project, packages a zip, and creates a GitHub Release named `assurance-forge <tag>` with the zip attached.
 4. Edit the Release on GitHub to add a description. The workflow leaves the body empty intentionally so the release notes can be written by hand.
 
 The release zip is named `assurance-forge.<tag>.zip` and contains:


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow for building and publishing Windows releases, plus user-facing and maintainer-facing documentation.

## Changes

- `.github/workflows/release.yml` — new workflow:
  - Triggers:
    - **Tag push** (semver-style tags like `0.1.0`, `0.1.0-alpha.5`): builds and creates a GitHub Release with the zip attached; tags containing `-` are auto-marked as prerelease
    - **Manual `workflow_dispatch`**: builds and uploads the zip as a workflow artifact only (no Release created), useful for experimental builds
  - Builds on `windows-latest` with the Visual Studio 2022 generator
  - Packages a zip containing `assurance-forge.exe`, `data/`, `README.md`, `LICENSE.md`
- `docs/RELEASING.md` — new maintainer guide describing tag conventions, how to cut a release, and how to use experimental builds
- `README.md` — adds a **Releases** section pointing users to the GitHub Releases page

## Notes on file naming

The release zip is named `assurance-forge.<version>-windows-x64.zip`, keeping the existing dot-separated style from previous releases (e.g. `assurance-forge.0.1.0-alpha.5.zip`) and adding a `-windows-x64` suffix to leave room for future cross-platform artifacts. Happy to adjust if you'd prefer a different convention.

## Testing

End-to-end verification was performed on my fork (so no test tags or releases were created on `lasrod/assurance-forge`):

- Pushed a test tag and confirmed the workflow runs, builds successfully, and creates a Release with the zip attached
- Confirmed prerelease detection works for `-alpha` tags
- Verified `workflow_dispatch` runs and produces a downloadable artifact without creating a Release
- Confirmed the produced zip extracts cleanly and `assurance-forge.exe` runs

## Review focus

A few points where your input would be especially useful:

- **Release notes workflow**: The workflow leaves the Release body empty so notes can be written by hand, matching the current practice. Let me know if you'd prefer auto-generated notes from commits/PRs.
- **Zip filename convention**: see "Notes on file naming" above
- **Tag trigger pattern**: Currently triggers on any tag matching semver shape. Let me know if you'd like to restrict it further.

## Out of scope

- Linux/macOS release artifacts (planned for the cross-platform builds task)
- Test execution in CI (planned as the next task)
- Code coverage (planned as a later task)
- Code signing / notarization