### PR TITLE
Add CI workflow and run tests before release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    name: Build & Test (Windows)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Configure CMake
+        run: cmake -B build -G "Visual Studio 17 2022" -A x64
+
+      - name: Build (Debug)
+        run: cmake --build build --config Debug
+
+      - name: Run tests
+        run: ctest --test-dir build -C Debug --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
         run: cmake --build build --config Debug
 
       - name: Run tests
-        run: ctest --test-dir build -C Debug --output-on-failure
+        run: ctest --test-dir build -C Debug --output-on-failure --no-tests=error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Build (Release)
         run: cmake --build build --config Release
 
+      - name: Run tests
+        run: ctest --test-dir build -C Release --output-on-failure
+
       - name: Determine package version
         id: version
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         run: cmake --build build --config Release
 
       - name: Run tests
-        run: ctest --test-dir build -C Release --output-on-failure
+        run: ctest --test-dir build -C Release --output-on-failure --no-tests=error
 
       - name: Determine package version
         id: version


### PR DESCRIPTION
## Summary

Adds a CI workflow that builds and tests on every push and pull request, and injects the same test step into the release workflow so releases are gated on green tests.

## Changes

- `.github/workflows/ci.yml` — new workflow:
  - Triggers: `push` to `main`, `pull_request` (any branch), and manual `workflow_dispatch`
  - Builds on `windows-latest` (Debug config) and runs the GoogleTest suite via `ctest`
- `.github/workflows/release.yml` — adds a `Run tests` step between `Build (Release)` and the existing packaging steps. Test failure halts the workflow before any zip / Release is produced.

## Notes on the design

I kept `ci.yml` and `release.yml` as separate files rather than factoring the shared steps (checkout / configure / build / test) into a composite action. The duplication is ~4 lines per workflow and each file remains readable on its own. `ci.yml` uses Debug for fast feedback on every push/PR; `release.yml` stays on Release so the test step exercises the actual release artifact.

## Testing

`ci.yml` runs as part of this PR — GitHub Actions reads workflow files from the PR's merge ref, so the CI check on this PR is itself a live demonstration of the workflow that will exist on `lasrod/main` after merge. (This contrasts with #40, which was tag-triggered and had to be verified after merge.)

For `release.yml`'s new test step, end-to-end verification was performed on my fork:

- **Happy path** ([job log](https://github.com/naozine/assurance-forge/actions/runs/24985164765/job/73156510706)): tagged `0.1.0-alpha.7-task2-ok` from this branch — full release flow ran build → test (`ctest -C Release`, 60/60 passed) → zip → Release, all green
- **Failure case** ([job log](https://github.com/naozine/assurance-forge/actions/runs/24985331218/job/73157062718)): temporarily broke an assertion in `tests/test_layout.cpp` on a throwaway branch and tagged `0.1.0-alpha.7-task2-fail` — `Run tests` failed at `LayoutTest.LeafNodeHasWidth1`, downstream packaging steps skipped, no Release created

The test tags / releases / branches on the fork have been cleaned up, but the workflow runs above (including full ctest output and the happy-path zip artifact) remain accessible.

## Acceptance criteria

| # | Criterion | Status |
|---|---|---|
| 1 | CI runs on push and pull request | ✅ `ci.yml` triggers on `push: main`, `pull_request`, `workflow_dispatch` |
| 2 | Project builds successfully | ✅ both workflows build via `cmake --build` |
| 3 | Tests run automatically | ✅ `ctest` step in both workflows |
| 4 | CI fails if tests fail | ✅ verified in failure-case run above |
| 5 | Instructions for local test execution are documented | ✅ already covered in `README.md` §"5. Run Tests" |
| 6 | CI output clearly shows test results | ✅ `--output-on-failure` flag + per-test ctest output (see job logs above) |

## Out of scope

- Linux / macOS CI (planned for the cross-platform builds task)
- Code coverage (planned as a later task)