### PR TITLE
Add Linux and macOS release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,38 @@ permissions:
   contents: write
 
 jobs:
-  build-windows:
-    name: Build (Windows)
-    runs-on: windows-latest
+  build:
+    name: Build (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows
+            os: windows-latest
+            configure: cmake -B build -G "Visual Studio 17 2022" -A x64
+            build: cmake --build build --config Release
+            test: ctest --test-dir build -C Release --output-on-failure --no-tests=error
+            binary_path: build/Release/assurance-forge.exe
+            archive_suffix: windows-x64
+            archive_ext: zip
+          - name: Linux
+            os: ubuntu-latest
+            configure: cmake -B build -DHELLOIMGUI_DOWNLOAD_GLFW_IF_NEEDED=ON -DCMAKE_BUILD_TYPE=Release
+            build: cmake --build build
+            test: ctest --test-dir build --output-on-failure --no-tests=error
+            binary_path: build/assurance-forge
+            archive_suffix: linux-x64
+            archive_ext: tar.gz
+          - name: macOS
+            os: macos-latest
+            configure: cmake -B build -DCMAKE_BUILD_TYPE=Release
+            build: cmake --build build
+            test: ctest --test-dir build --output-on-failure --no-tests=error
+            binary_path: build/assurance-forge.app
+            archive_suffix: macos-arm64
+            archive_ext: zip
 
     steps:
       - name: Checkout (with submodules)
@@ -21,14 +50,20 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xorg-dev libgl1-mesa-dev libglu1-mesa-dev libgtk-3-dev
+
       - name: Configure CMake
-        run: cmake -B build -G "Visual Studio 17 2022" -A x64
+        run: ${{ matrix.configure }}
 
       - name: Build (Release)
-        run: cmake --build build --config Release
+        run: ${{ matrix.build }}
 
       - name: Run tests
-        run: ctest --test-dir build -C Release --output-on-failure --no-tests=error
+        run: ${{ matrix.test }}
 
       - name: Determine package version
         id: version
@@ -46,25 +81,50 @@ jobs:
           set -euo pipefail
           stage="package/assurance-forge.${{ steps.version.outputs.version }}"
           mkdir -p "$stage"
-          cp build/Release/assurance-forge.exe "$stage/"
-          cp -r assets "$stage/"
-          cp -r data "$stage/"
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            cp -R "${{ matrix.binary_path }}" "$stage/"
+          else
+            cp "${{ matrix.binary_path }}" "$stage/"
+            cp -R assets "$stage/"
+          fi
+          cp -R data "$stage/"
           cp README.md "$stage/"
           cp LICENSE.md "$stage/"
 
-      - name: Create zip
+      - name: Create archive (Windows)
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
           $version = "${{ steps.version.outputs.version }}"
           $stage = "package/assurance-forge.$version"
-          $zip = "package/assurance-forge.$version-windows-x64.zip"
-          Compress-Archive -Path $stage -DestinationPath $zip -Force
+          $archive = "package/assurance-forge.$version-${{ matrix.archive_suffix }}.${{ matrix.archive_ext }}"
+          Compress-Archive -Path $stage -DestinationPath $archive -Force
+
+      - name: Create archive (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          stage_name="assurance-forge.${version}"
+          archive="package/assurance-forge.${version}-${{ matrix.archive_suffix }}.${{ matrix.archive_ext }}"
+          tar -czf "$archive" -C package "$stage_name"
+
+      - name: Create archive (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          stage_name="assurance-forge.${version}"
+          archive="package/assurance-forge.${version}-${{ matrix.archive_suffix }}.${{ matrix.archive_ext }}"
+          (cd package && zip -r -y "../$archive" "$stage_name")
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v6
         with:
-          name: assurance-forge-${{ steps.version.outputs.version }}-windows-x64
-          path: package/assurance-forge.${{ steps.version.outputs.version }}-windows-x64.zip
+          name: assurance-forge-${{ steps.version.outputs.version }}-${{ matrix.archive_suffix }}
+          path: package/assurance-forge.${{ steps.version.outputs.version }}-${{ matrix.archive_suffix }}.${{ matrix.archive_ext }}
           if-no-files-found: error
 
       - name: Create GitHub Release
@@ -73,5 +133,5 @@ jobs:
         with:
           name: assurance-forge ${{ steps.version.outputs.version }}
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
-          files: package/assurance-forge.${{ steps.version.outputs.version }}-windows-x64.zip
+          files: package/assurance-forge.${{ steps.version.outputs.version }}-${{ matrix.archive_suffix }}.${{ matrix.archive_ext }}
           fail_on_unmatched_files: true


### PR DESCRIPTION
# Add Linux and macOS release artifacts

## Summary

Follows #48 by extending the release pipeline to produce Linux and macOS artifacts alongside the existing Windows zip. The release workflow now runs as a 3-OS matrix mirroring the structure of `ci.yml`. Tagging a release publishes all three archives to the same GitHub Release object.

Per-OS conventions:
- **Windows**: `.zip` via `Compress-Archive`
- **Linux**: `.tar.gz` via `tar -czf`
- **macOS**: `.zip` of the `.app` bundle produced by `hello_imgui_add_app`, via `zip -r -y` (`-y` is the standard practice when zipping `.app` bundles — preserves symlinks for any bundled frameworks)

## Implementation notes

- The macOS `.app` already bundles `assets/` into `Contents/Resources/` via `hello_imgui_bundle_assets`, so the staging step skips the explicit `assets/` copy on macOS while keeping it alongside the binary on Windows and Linux.
- `data/`, `README.md`, and `LICENSE.md` ship at the top of the archive on all three OSes.

Resulting archive layout:

```
package/assurance-forge.<version>/
├── assurance-forge[.exe]              # Windows / Linux only
├── assets/                            # Windows / Linux only
│   └── fonts/...
├── assurance-forge.app/               # macOS only
│   └── Contents/Resources/assets/fonts/...
├── data/                              # all 3 OSes
├── README.md                          # all 3 OSes
└── LICENSE.md                         # all 3 OSes
```

- `softprops/action-gh-release@v3` upserts the Release object — each matrix job uploads its own archive against the same tag and they accumulate as Release assets.
- The Linux runner installs `xorg-dev libgl1-mesa-dev libglu1-mesa-dev libgtk-3-dev` to satisfy GLFW and nativefiledialog-extended (GTK3) build requirements.

## Verification

Performed on a fork before opening this PR:

- **workflow_dispatch run** ([25087174659](https://github.com/naozine/assurance-forge/actions/runs/25087174659)): 3-OS matrix green; three workflow artifacts produced (`assurance-forge-dev-<sha>-{windows-x64, linux-x64, macos-arm64}`).
- **Tag-triggered run** ([25087321233](https://github.com/naozine/assurance-forge/actions/runs/25087321233), tag `0.0.0-rc1`): 3-OS matrix green; the GitHub Release object aggregates all three archives.
- **Local extraction smoke** on all three OSes:
  - Windows `.zip`: extracted, `assurance-forge.exe` ran from the unpacked folder.
  - Linux `.tar.gz`: extracted, executable ran.
  - macOS `.zip`: extracted, quarantine cleared via `xattr` (see Known limitations), `.app` launched — Japanese fonts and main UI verified.
- **NFD smoke**: `nativefiledialog-extended` open/save dialogs confirmed on Linux (Ubuntu 24, Wayland — GTK3) and macOS (Cocoa).

## Known limitations

- The macOS build is unsigned and unnotarized. On first launch, Gatekeeper reports the app as damaged; clearing the quarantine attribute lets it run:
  ```
  xattr -dr com.apple.quarantine /path/to/assurance-forge.app
  ```
  Codesign / notarization is intentionally out of scope.
- `macos-latest` runners are arm64-only, so the macOS artifact ships as `macos-arm64`. Intel builds remain a from-source path.
- The macOS artifact ships as a `.zip` of the `.app`. A `.dmg` disk image is the more familiar macOS distribution format (drag-to-Applications install flow) but does not bypass Gatekeeper for unsigned builds; left as a possible future enhancement.
- The Linux artifact ships as `.tar.gz`. AppImage would offer a more polished single-file UX but requires additional packaging infrastructure (linuxdeploy + AppDir); left as a possible future enhancement.
- The macOS `.app` ships with HelloImGui's default icon (the framework's logo); the Windows `.exe` has no embedded icon (system default). HelloImGui can produce platform-specific icons from a single `assets/app_settings/icon.png`; adding one is left as a follow-up.

## Test plan

- [x] `workflow_dispatch` run on a fork: 3-OS matrix green, three workflow artifacts produced
- [x] Tag-triggered run on a fork (`0.0.0-rc1`): 3-OS matrix green, GitHub Release object aggregates all three archives
- [x] Local extraction + run on all three OSes (Windows `.zip`, Linux `.tar.gz`, macOS `.app` after quarantine clear)
- [x] `nativefiledialog-extended` open/save dialogs verified on Linux (Ubuntu 24, Wayland — GTK3) and macOS (Cocoa)
